### PR TITLE
Don't render selector when we're not able to place blocks at the target

### DIFF
--- a/js/dev/main.js
+++ b/js/dev/main.js
@@ -695,6 +695,11 @@ class Game {
             if(chunkId != null) {
               this.world.rebuild_specific_chunk(chunkId);
             }
+
+            this.selector.material.visible = true;
+        } else {
+            // don't render selector when we can't place blocks here
+            this.selector.material.visible = false;
         }
 
         const spos = new THREE.Vector3(


### PR DESCRIPTION
This makes the selector invisible in the following cases:
- Escaped from pointer lock
- Aiming at a block outside of the world bounds (I found this very confusing, which is why I made this pull)
- Client is still syncing