### PR TITLE
Make selector stay in center of FOV, including when looking up

### DIFF
--- a/js/dev/main.js
+++ b/js/dev/main.js
@@ -614,11 +614,8 @@ class Game {
 
         const cobj = this.controls.getObject();
 
-        const cdir = new THREE.Vector3();
-        game.controls.getDirection(cdir);
-
-        const cpos = new THREE.Vector3(0, cdir.y, -1);
-        cpos.applyQuaternion(cobj.quaternion);
+        const cpos = new THREE.Vector3();
+        game.controls.getDirection(cpos);
         cpos.add(cobj.position);
 
         const bpos = new THREE.Vector3(


### PR DESCRIPTION
Currently it's rather difficult to build overhead or below feet because the selector doesn't align with the FOV when looking up or down. This commit fixes that.

I don't know if the existing behaviour was intentional, but it felt difficult to use and this is (in my opinion) more comfortable to work with.

Example: 
![image](https://user-images.githubusercontent.com/14214667/48268238-57f26f00-e42c-11e8-8ce6-d6c405b3ab0a.png)
With this change: 
![image](https://user-images.githubusercontent.com/14214667/48268339-9ab44700-e42c-11e8-8b8c-40c61663edc1.png)

This also facilitates building spheres more easily :)

